### PR TITLE
Add systemd service

### DIFF
--- a/flashfocus.service
+++ b/flashfocus.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Perform windows animations on focus
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+ExecStart=/usr/bin/flashfocus
+
+[Install]
+WantedBy=graphical-session.target


### PR DESCRIPTION
This service is for those who would like to run flashfocus as a systemd service, will not have any impact who don't want to do so 🙂 

When enabled, the service will auto-start after graphical session starts, and gracefully exit when graphical session is closed.

In your PKGBUILD, you should place this file in `/usr/lib/systemd/user/` folder, then it will be available for optional activation.

By the way, this will help with https://github.com/fennerm/flashfocus/issues/40, although in case of sway the user would have to additionally configure their `sway-session.target` as explained in [sway wiki](https://github.com/swaywm/sway/wiki/Systemd-integration).