### PR TITLE
relax pyyaml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ cffi>=1.11,<2.0.0
 xcffib>=0.6.0,<1.0.0
 click>=6.7,<9.0.0
 xpybutil>=0.0.6,<1.0.0
-pyyaml>=5.1,<6.0.0
+pyyaml>=5.1
 marshmallow >=2.15.0,<4.0.0
 i3ipc>=2.1.1,<3.0.0
 pdbpp

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         "cffi>=1.11,<2.0",
         "xpybutil>=0.0.6,<1.0",
         "marshmallow>=2.15,<4.0",
-        "pyyaml>=5.1,<6.0",
+        "pyyaml>=5.1",
         "i3ipc>=2.1.1,<3.0",
     ],
     packages=find_packages(exclude=["*test*"]),


### PR DESCRIPTION
the following has been in the nixpkgs package since jan 11 2022 and it
works
substituteInPlace setup.py \
  --replace "pyyaml>=5.1,<6.0" "pyyaml>=5.1"
  
  
  Closes https://github.com/fennerm/flashfocus/issues/71