### PR TITLE
fix the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM fennerm/arch-i3-novnc
 LABEL maintainer="fmacrae.dev@gmail.com"
 
 RUN pacman -Sy --noconfirm archlinux-keyring
+RUN yes | pacman-key --init
+RUN yes | pacman-key --populate archlinux
 RUN pacman -Syyu --noconfirm
 RUN pacman -S --noconfirm \
         gcc \


### PR DESCRIPTION
the error that showed was many of these

:: File /var/cache/pacman/pkg/gzip-1.12-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] error: gzip: signature from "Levente Polyak (anthraxx) <levente@leventepolyak.net>" is unknown trust

fix found in https://github.com/sickcodes/Docker-OSX/issues/485#issuecomment-1105978096

there's also a bug report at https://bugs.archlinux.org/task/75262