### PR TITLE
Bump marshmallow to >=4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "click>=6.7,<9.0",
   "cffi>=1.11,<2.0",
   "xpybutil>=0.0.6,<1.0",
-  "marshmallow>=2.15,<4.0",
+  "marshmallow>=4.0,<5.0",
   "pyyaml>=5.1",
   "i3ipc>=2.1.1,<3.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,10 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
   "Development Status :: 6 - Mature",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Desktop Environment :: Window Managers",
   "Topic :: Desktop Environment"
 ]
@@ -34,7 +33,7 @@ keywords=[
   "awesomewm",
   "herbsluftwm"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
   "xcffib>=0.6.0,<1.0",
   "click>=6.7,<9.0",
@@ -82,7 +81,7 @@ version = {attr = "flashfocus.__version__"}
 line-length = 100
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.10"
 files = ["flashfocus", "tests"]
 check_untyped_defs = true
 disallow_untyped_defs = true

--- a/src/flashfocus/config.py
+++ b/src/flashfocus/config.py
@@ -88,10 +88,10 @@ class BaseSchema(Schema):
     flash rules.
     """
 
-    flash_opacity: fields.Number = fields.Number(validate=validate_decimal)
-    default_opacity: fields.Number = fields.Number(validate=validate_decimal)  # noqa: E704
+    flash_opacity: fields.Float = fields.Float(validate=validate_decimal)
+    default_opacity: fields.Float = fields.Float(validate=validate_decimal)  # noqa: E704
     simple: fields.Boolean = fields.Boolean()
-    time: fields.Number = fields.Number(validate=validate_positive_number)
+    time: fields.Float = fields.Float(validate=validate_positive_number)
     ntimepoints: fields.Integer = fields.Integer(validate=validate_positive_number)
     flash_on_focus: fields.Boolean = fields.Boolean()
     flash_lone_windows: fields.String = fields.String(validate=validate_flash_lone_windows)


### PR DESCRIPTION
To fix the nixpkgs package because the marshmallow package was updated.

fields.Number should not be used directly anymore

https://marshmallow.readthedocs.io/en/latest/upgrading.html#number-and-mapping-fields-as-base-classes